### PR TITLE
Don't check return value of main smmstore() call

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,6 @@ mod smmstore;
 #[no_mangle]
 pub extern "C" fn main() -> Status {
     if let Err(err) = smmstore::smmstore() {
-        println!("SmmStore error: {:?}", err);
         Status::from_error(err)
     } else {
         Status(0)


### PR DESCRIPTION
If coreboot is built without SMMSTORE support, then the execution of this driver will result in an invalid opcode and hang. Mitigate this by not checking the return value of the main smmstore function, since a graceful exit when SMMSTORE not enabled is the proper behavior.

Tested on an AMD Chromebook w/upstream coreboot, with and without
CONFIG_SMMSTORE enabled.

Signed-off-by: Matt DeVillier <matt.devillier@gmail.com>