### PR TITLE
Replace cargo-xbuild with build-std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,14 +23,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlibc"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "system76_firmware_smmstore"
 version = "1.0.0"
 dependencies = [
  "redox_uefi 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_uefi_std 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rlibc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
 "checksum redox_uefi 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dafc50645c27c55ca19d27645a6d91e2a8cbc7aabb2ed024ce914512c75e1217"
 "checksum redox_uefi_alloc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "72e7224e2106fdc2a35a33e38825f4867c3566671dc496fb67b992d05328e564"
 "checksum redox_uefi_std 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ead5c13a8a650646b2f93065002d65b45226cdbc6494b0ac4aaed30ce9b17c7f"
+"checksum rlibc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,4 @@ crate-type = ["staticlib"]
 [dependencies]
 redox_uefi = "0.1.0"
 redox_uefi_std = "0.1.0"
-
-[package.metadata.cargo-xbuild]
-memcpy = true
-sysroot_path = "build/xbuild"
+rlibc = "1.0"

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,8 @@ $(BUILD)/boot.o: $(BUILD)/boot.a
 
 $(BUILD)/boot.a: Cargo.lock Cargo.toml res/* src/*
 	mkdir -p $(BUILD)
-	cargo xrustc \
+	cargo rustc \
+		-Z build-std=core,alloc \
 		--lib \
 		--target $(TARGET) \
 		--release \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(try_trait)]
 #![allow(non_snake_case)]
 
+extern crate rlibc;
 #[macro_use]
 extern crate uefi_std as std;
 


### PR DESCRIPTION
Use [build-std](https://doc.rust-lang.org/cargo/reference/unstable.html#build-std) instead of cargo-xbuild. This requires adding a dependency on rlibc, since the `mem` feature of `compiler_builtins` cannot be enabled [\[1\]](https://github.com/rust-lang/cargo/pull/7216#issuecomment-529433594).