### PR TITLE
Convert toolchain file to TOML syntax

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,3 @@
-nightly-2020-07-27
+[toolchain]
+channel = "nightly-2020-07-27"
+components = ["rust-src"]


### PR DESCRIPTION
rustup 1.23.0 (2020-11-27) introduced support for TOML syntax for the
toolchain file. Use this and specify required compoenents.

To ensure you are using a new enough rustup, run:

    rustup self update